### PR TITLE
Unit tests and file size fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .buildconfig
+build

--- a/data/org.organiza.Organiza.appdata.xml.in
+++ b/data/org.organiza.Organiza.appdata.xml.in
@@ -3,6 +3,7 @@
 	<id>org.organiza.Organiza.desktop</id>
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>LicenseRef-proprietary</project_license>
+  <!-- TODO add screenshot tag, because unit test complains about it! -->
 	<description>
 	</description>
 </component>

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,5 @@
-project('organiza', ['c', 'vala'],        version: '0.1.0',
+project('organiza', ['c', 'vala'],
+  version: '0.1.0',
   meson_version: '>= 0.40.0',
 )
 

--- a/src/files/fileutil.vala
+++ b/src/files/fileutil.vala
@@ -2,30 +2,131 @@ using GLib.Math;
 
 namespace FileUtil {
 
+    const int64 KILO = 1024;
+    const int64 MEGA = 1048576;
+    const int64 GIGA = 1073741824;
+    const int64 TERA = 1099511627776;
+    const int64 PETA = 1125899906842624;
+    const int64 EXA = 1152921504606846976;
+
     /**
      * Converts a given file size into a simple, binary representation, that is
-     * meant to be comprehensible to humans.
+     * meant to be comprehensible to human nerds.
+     *
+     * While the rest of the world has standardized on the meanings of
+     *
+     * * kilo (1000)
+     * * mega (1000^2)
+     * * giga (1000^3)
+     * * tera (1000^4)
+     * * peta (1000^5)
+     * * exa (1000^6)
+     *
+     * computer scientist of course, had to be special snowflakes and repurpose
+     * those words as
+     *
+     * * kilo (1024)
+     * * mega (1024^2)
+     * * giga (1024^3)
+     * * tera (1024^4)
+     * * peta (1024^5)
+     * * exa (1024^6)
+     *
+     * because 1024 is a power of 2 and for hackers it makes a lot of sense to
+     * talk about file sizes in base 2.
+     *
+     * This has lead to the confusing situation where hard drive manufactureres
+     * state disk sizes with one standard, but software reports size with another.
+     *
+     * There has been an effort to standardize away from the established terms by
+     * inventing new ones for base 2 sizes (kibi, mibi, gibi,...) but those have
+     * been largely ignored.
+     *
+     * Since we do not want to upset the fragile minds of hackers, the intended
+     * audience for this tool, we stick to the classical nomenclature (kilo, mega,...)
+     * but report sizes in base 2.
+     *
+     * In GLib file sizes cannot exceed int64.MAX (18446744073709551615 == 2^64 - 1) bytes.
+     * For this reason, we cannot exceed sizes larger than exa (1152921504606846976 == 2^60).
+     * But who would ever need that much storage? Seems crazy, right? Right *sarcasm-face*?
+     *
+     * Additionally, in order to avoid localization issues (comma vs. period), this
+     * function returns integer precision sizes.
+     *
+     * Sources:
+     *
+     * * [[https://en.wikipedia.org/wiki/Binary_prefix|wikipedia.org/Binary_prefix]]
+     * * [[https://en.wikipedia.org/wiki/International_System_of_Units|wikipedia.org/International_System_of_Units]]
+     * * [[https://en.wikipedia.org/wiki/International_Electrotechnical_Commission|wikipedia.org/International_Electrotechnical_Commission]]
+     * * [[https://networkengineering.stackexchange.com/questions/3628/iec-or-si-units-binary-prefixes-used-for-network-measurement|networkengineering.stackexchange.com/iec-or-si-units-binary-prefixes-used-for-network-measurement]]
+     *
+     * @param file_size the file size in bytes, as reportes by GLib.
+     *
+     * @return a readable, consise formatting of the given file size. Will be empty
+     * if ``file_size`` is negative.
      */
-    public string as_human_readable_binary(int64 file_size){
-        const int64 unit = 1024;
-        if (file_size < unit)
+    public string as_nerd_readable_file_size(int64 file_size){
+        if(file_size < 0)
         {
-            return file_size.to_string() + " B";
+            //what does a negative file size even mean?
+            // obviously, FileInfo.get_size mentions none of it...
+            return "";
         }
-        int64 exp = (int64) (Math.log(file_size) / Math.log(unit));
-        string pre = "KMGTPE".get_char((long)exp-1).to_string() + "i";
-        return format("%.1f %sB", file_size / pow(unit, exp), pre);
-    }
 
-    private string format(string some_string, ...){
-        va_list va_list = va_list();
-        return some_string.vprintf(va_list);
+        double normalized_size = (double) file_size;
+        var suffix = "B";
+
+        // in case of performance concerns, the order of these if-blocks
+        // could be swapped. however, without benchmarks that would be pointless.
+        // even with benchmarks, one has to consider typical file sizes (1KB - 1 GB
+        // in 2018, would be my guess) as opposed to all possible file sizes.
+        //
+        // i have also experimented with fast bitwise integer operations.
+        // however, that proved to be very imprecise for any number not cleanly
+        // divisible by 2. i am sure, it would be possible enhance the accuracy
+        // of integer divisions, but
+        // a. the effort should only be undertaken in case of perf problems
+        // b. surely, some lib out there has solved this already.
+
+        if(file_size >= KILO)
+        {
+            normalized_size = normalized_size / 1024;
+            suffix="KB";
+        }
+        if(file_size >= MEGA)
+        {
+            normalized_size = normalized_size / 1024;
+            suffix="MB";
+        }
+        if(file_size >= GIGA)
+        {
+            normalized_size = normalized_size / 1024;
+            suffix="GB";
+        }
+        if(file_size >= TERA)
+        {
+            normalized_size = normalized_size / 1024;
+            suffix="TB";
+        }
+        if(file_size >= PETA)
+        {
+            normalized_size = normalized_size / 1024;
+            suffix="PB";
+        }
+        if(file_size >= EXA)
+        {
+            normalized_size = normalized_size / 1024;
+            suffix="EB";
+        }
+
+        return @"$(round(normalized_size)) $suffix";
     }
 
     /**
      * Queries a file to check if it is a directory.
      */
     public bool is_directory (File file) {
+        //FIXME: GLib already has FileUtils and FileTest for this purpose.
         return file.query_file_type(FileQueryInfoFlags.NONE) == FileType.DIRECTORY;
     }
 

--- a/src/files/fileutiltest.vala
+++ b/src/files/fileutiltest.vala
@@ -1,0 +1,76 @@
+namespace Tests {
+    using Test;
+    using FileUtil;
+
+    void add_fileutil_tests () {
+        Test.add_func ("/files/fileutil/as_nerd_readable_file_size", () => {
+
+        assert_equals (as_nerd_readable_file_size(-1), "");
+        assert_equals (as_nerd_readable_file_size(-100), "");
+
+        assert_equals (as_nerd_readable_file_size(0), "0 B");
+        assert_equals (as_nerd_readable_file_size(1), "1 B");
+        assert_equals (as_nerd_readable_file_size(2), "2 B");
+        assert_equals (as_nerd_readable_file_size(55), "55 B");
+        assert_equals (as_nerd_readable_file_size(99), "99 B");
+        assert_equals (as_nerd_readable_file_size(999), "999 B");
+        assert_equals (as_nerd_readable_file_size(1023), "1023 B");
+
+        // 1024^1 1024 B == 1 KB
+        assert_equals (as_nerd_readable_file_size(1000), "1000 B");
+        assert_equals (as_nerd_readable_file_size(1024), "1 KB");
+        assert_equals (as_nerd_readable_file_size(34647), "34 KB");
+        assert_equals (as_nerd_readable_file_size(654323), "639 KB");
+
+        // 1024^2 == 1048576 B == 1 MB
+        assert_equals (as_nerd_readable_file_size(1048570), "1024 KB");
+        assert_equals (as_nerd_readable_file_size(1048576), "1 MB");
+        assert_equals (as_nerd_readable_file_size(6564567), "6 MB");
+        assert_equals (as_nerd_readable_file_size(13265667), "13 MB");
+
+        // 1024^3 == 1073741824 == 1 GB
+        assert_equals (as_nerd_readable_file_size(1073741820), "1024 MB");
+        assert_equals (as_nerd_readable_file_size(1073741824), "1 GB");
+        assert_equals (as_nerd_readable_file_size(45179874321), "42 GB");
+        assert_equals (as_nerd_readable_file_size(886879874321), "826 GB");
+
+        // 1024^4 == 1099511627776 == 1 TB
+        assert_equals (as_nerd_readable_file_size(1099511627770), "1024 GB");
+        assert_equals (as_nerd_readable_file_size(1099511627776), "1 TB");
+        assert_equals (as_nerd_readable_file_size(86745676536574), "79 TB");
+        assert_equals (as_nerd_readable_file_size(134165765398211), "122 TB");
+
+        // 1024^5 == 1125899906842624 == 1 PB
+        assert_equals (as_nerd_readable_file_size(1125899906842620), "1024 TB");
+        assert_equals (as_nerd_readable_file_size(1125899906842624), "1 PB");
+        assert_equals (as_nerd_readable_file_size(71176567887330129), "63 PB");
+        assert_equals (as_nerd_readable_file_size(790963723023183838), "703 PB");
+
+        // 1024^6 == 1152921504606846976 == 1 EB
+        assert_equals (as_nerd_readable_file_size(1152921504606846970), "1024 PB");
+        assert_equals (as_nerd_readable_file_size(1152921504606846976), "1 EB");
+        assert_equals (as_nerd_readable_file_size(7154921204676846234), "6 EB");
+
+        //int64.MAX
+        assert_equals (as_nerd_readable_file_size(9223372036854775807), "8 EB");
+        });
+    }
+
+    inline void assert_equals(string actual, string expected){
+        if(expected == actual){
+            //in case of vala black magic, pass check expression again:
+            assert (expected == actual);
+        }
+        else
+        {
+            GLib.message(@"Expected value '$expected', but got '$actual' instead.");
+            Test.fail();
+        }
+    }
+
+    void main (string[] args) {
+        Test.init (ref args);
+        add_fileutil_tests ();
+        Test.run ();
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,13 +1,13 @@
+# These sources are shared with the min application and unit tests.
 organiza_sources = [
   'files/fileutil.vala',
-  'main.vala',
   'window.vala',
 ]
 
 organiza_deps = [
-  dependency('gio-2.0', version: '>= 2.50'),
-  dependency('gtk+-3.0', version: '>= 3.22'),
-  dependency('glib-2.0', version: '>= 2.50'),
+  dependency('gio-2.0', version: '>= 2.48'),
+  dependency('gtk+-3.0', version: '>= 3.18'),
+  dependency('glib-2.0', version: '>= 2.48'),
 ]
 
 gnome = import('gnome')
@@ -17,10 +17,18 @@ organiza_sources += gnome.compile_resources('organiza-resources',
   c_name: 'organiza'
 )
 
-executable('organiza', organiza_sources,
+executable('organiza', organiza_sources, 'main.vala',
   dependencies: organiza_deps,
   # link in libm (math).
-  # this seems necessary to have access to GLib.Math. Not sure why, but probaly a hack!
+  # this seems necessary to have access to GLib.Math. Not sure why ...
   link_args: '-lm',
   install: true,
 )
+
+fileutil = executable( 'fileutiltest',
+  'files/fileutiltest.vala',
+  organiza_sources,
+  dependencies:organiza_deps,
+  link_args: '-lm',
+)
+test('Testing file utilities.', fileutil)

--- a/src/window.vala
+++ b/src/window.vala
@@ -40,6 +40,7 @@ namespace Organiza {
             try {
                 currentFolderHierarchy.clear ();
                 var directory = File.new_for_path (currentRootDirectory);
+                //FIXME The documentation suggests to use enumerate_children_async to not block the thread.
                 var enumerator = directory.enumerate_children ("standard::*", FileQueryInfoFlags.NONE);
 
                 FileInfo childFileInfo;
@@ -52,8 +53,7 @@ namespace Organiza {
                         //Calculating a directories recursively takes too long, therefore we won't display such info.
                         fileSize = "";
                     } else {
-                        //TODO Format this to be human readable.
-                        fileSize = FileUtil.as_human_readable_binary(childFileInfo.get_size ());
+                        fileSize = FileUtil.as_nerd_readable_file_size(childFileInfo.get_size ());
                     }
 
                     //TODO Currently the displayed item is just a forbidden sign; find a way to find the mime types icon.


### PR DESCRIPTION
@tests Added scaffolding for unit tests.

the first test suite is for `fileutils.vala`. Gnome Builder complains
about a duplicate `main` method, but that seems to be bogus, since meson
builds fine.

future unit test can either copy the approach taken here (test() in
`meson.build` + seperate source file) or move the current
`fileutiltest.vala` into a more central localtio, rename it and start
using it as one giant test suite for the whole app.

@feature nerd friendly file sizes

historically, reporting on file sizes has been wonky because of
differing industry standards. the current method reflects the needs of
the target audience => binary/base 2 and rounded for consiceness.