### PR TITLE
YAML in editorconfig and travis fix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -38,6 +38,10 @@ indent_style = space
 indent_size = 4
 tab_size = 4
 
+[*.yml]
+indent_size = 2
+indent_style = space
+
 [meson.build]
 indent_size = 2
 indent_style = space

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
     "apt-get update && apt-get -y install $DEPENDENCY_PACKAGES && cd
     /tmp/build-dir && meson build && ninja -C build test"
   - >-
-    docker run -v "$PWD":/tmp/build-dir elementary/docker:loki-unstable' /bin/sh
+    docker run -v "$PWD":/tmp/build-dir elementary/docker:loki-unstable /bin/sh
     -c "apt-get update && apt-get -y install $DEPENDENCY_PACKAGES && cd
     /tmp/build-dir && meson build && ninja -C build test"
   - >-


### PR DESCRIPTION
- YAML requires spaces instead of tabs, thus we enforce it
- a single "'" seems to have snuck into the travis build file